### PR TITLE
Add Link to Atom Feed

### DIFF
--- a/_includes/sidebar.html
+++ b/_includes/sidebar.html
@@ -29,6 +29,7 @@
       <a class="sidebar-nav-item" href="https://the-force-engine.freeforums.net/">Forums</a>
       <a class="sidebar-nav-item" href="https://discord.gg/hpsJnY9">Discord</a>
       <a class="sidebar-nav-item" href="https://github.com/luciusDXL/TheForceEngine">GitHub project</a>
+      <a class="sidebar-nav-item" href="https://theforceengine.github.io/atom.xml">Atom Feed</a>
       <span class="sidebar-nav-item">Currently v{{ site.version }}</span>
     </nav>
 


### PR DESCRIPTION
This just adds a little link to the site's Atom feed in the sidebar.